### PR TITLE
Update to scripts for helm related templates

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -54,7 +54,7 @@ echo -e "BUILDING CONTAINER IMAGE: ${IMAGE_NAME}:${IMAGE_TAG}"
 if [ -z "${DOCKER_ROOT}" ]; then DOCKER_ROOT=. ; fi
 if [ -z "${DOCKER_FILE}" ]; then DOCKER_FILE=${DOCKER_ROOT}/Dockerfile ; fi
 set -x
-bx cr build -t ${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG} ${DOCKER_ROOT} -f ${DOCKER_FILE}
+bx cr build -f ${DOCKER_FILE} -t ${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG} ${DOCKER_ROOT}
 set +x
 
 bx cr image-inspect ${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -52,9 +52,9 @@ IMAGE_TAG=${BUILD_NUMBER}-${IMAGE_TAG}
 echo "=========================================================="
 echo -e "BUILDING CONTAINER IMAGE: ${IMAGE_NAME}:${IMAGE_TAG}"
 if [ -z "${DOCKER_ROOT}" ]; then DOCKER_ROOT=. ; fi
-if [ -z "${DOCKER_FILE}" ]; then DOCKER_FILE=${DOCKER_ROOT}/Dockerfile ; fi
+if [ -z "${DOCKER_FILE}" ]; then DOCKER_FILE=Dockerfile ; fi
 set -x
-bx cr build -f ${DOCKER_FILE} -t ${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG} ${DOCKER_ROOT}
+bx cr build -f ${DOCKER_ROOT}/${DOCKER_FILE} -t ${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG} ${DOCKER_ROOT}
 set +x
 
 bx cr image-inspect ${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}

--- a/scripts/build_umbrella_chart.sh
+++ b/scripts/build_umbrella_chart.sh
@@ -10,6 +10,7 @@
 
 # This script does build a complete umbrella chart with resolved dependencies, leveraging a sibling local chart repo (/charts)
 # which would be updated from respective CI pipelines (see also https://raw.githubusercontent.com/open-toolchain/commons/master/scripts/publish_helm_package.sh)
+CHART_NAME=${CHART_NAME:-'umbrella-chart'}
 echo "BUILD_NUMBER=${BUILD_NUMBER}"
 echo "ARCHIVE_DIR=${ARCHIVE_DIR}"
 echo "CHART_NAME=${CHART_NAME}"
@@ -36,7 +37,6 @@ helm init --client-only
 #helm repo add components ${GIT_REMOTE_URL}/raw/master/charts
 #helm repo add components "${GIT_REMOTE_URL%'.git'}/raw/master/charts"
 
-CHART_NAME=umbrella-chart
 CHART_PATH=./${CHART_NAME}
 
 # Compute chart version number

--- a/scripts/check_prebuild.sh
+++ b/scripts/check_prebuild.sh
@@ -30,7 +30,7 @@ echo "Checking for Dockerfile at the repository root"
 if [ -z "${DOCKER_ROOT}" ]; then DOCKER_ROOT=. ; fi
 if [ -z "${DOCKER_FILE}" ]; then DOCKER_FILE=Dockerfile ; fi
 if [ -f ${DOCKER_ROOT}/${DOCKER_FILE} ]; then 
-echo -e "Dockerfile found at: ${DOCKER_FILE}"
+    echo -e "Dockerfile found at: ${DOCKER_FILE}"
 else
     echo "Dockerfile not found at: ${DOCKER_FILE}"
     exit 1

--- a/scripts/publish_component_helm_chart.sh
+++ b/scripts/publish_component_helm_chart.sh
@@ -94,7 +94,7 @@ helm package ${CHART_PATH} --version $VERSION -d ./.publish/charts
 echo "Capture Insights matching config"
 mkdir -p ./.publish/insights
 INSIGHTS_FILE=./.publish/insights/${CHART_NAME}-${VERSION}
-rm -f INSIGHTS_FILE # override if already exists
+rm -f $INSIGHTS_FILE # override if already exists
 # Evaluate the gate against the version matching the git commit
 PIPELINE_STAGE_INPUT_REV=${SOURCE_BUILD_NUMBER}
 echo "BUILD_PREFIX=${BUILD_PREFIX}" >> $INSIGHTS_FILE


### PR DESCRIPTION
- `build_image.sh`: For `bx cr build`  -f needs to be before the path to be take in account. Also the the Dockerfile location was not consistent with `check_prebuild.sh`

- `build_umbrella_chart.sh`: Allow the name of the umbrella chart to be provided using environment variable

- `publish_component_helm_chart.sh`: INSIGHTS_FILE environment variable was not used for the `rm -f`