### PR TITLE
Add condition to prevent moving forward is cluster not reachable

### DIFF
--- a/scripts/check_predeploy_kubectl.sh
+++ b/scripts/check_predeploy_kubectl.sh
@@ -46,6 +46,10 @@ if [ ! -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
   kubectl config use-context custom-context
 fi
 kubectl cluster-info
+if [ "$?" != "0" ]; then
+  echo -e "${red}Kubernetes cluster seems not reachable${no_color}"
+  exit 1
+fi
 
 echo "=========================================================="
 echo "CHECKING DEPLOYMENT.YML manifest"


### PR DESCRIPTION
Needs this to have hybrid-kube-toolchain template to fail early in the deploy to PROD (private) if trying to reach a non publicly available ICP