### PR TITLE
Update commons script to ease usage/consumption for helm based deployment

### DIFF
--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -255,7 +255,7 @@ if [ ! -z "${APP_SERVICE}" ]; then
     echo "Using first worker node ip address as NodeIP: ${IP_ADDR}"
   else 
     # check if a route resource exists in the this kubernetes cluster
-    if kubectl explain route; then
+    if kubectl explain route > /dev/null 2>&1; then
       # Assuming the kubernetes target cluster is an openshift cluster
       # Check if a route exists for exposing the service ${APP_SERVICE}
       if  kubectl get routes --namespace ${CLUSTER_NAMESPACE} -o json | jq --arg service "$APP_SERVICE" -e '.items[] | select(.spec.to.name==$service)'; then

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -201,7 +201,7 @@ echo "SHOWING last events"
 kubectl get events --sort-by=.metadata.creationTimestamp -n ${CLUSTER_NAMESPACE}
 
 # Record deploy information
-if jq -e '.services[] | select(.service_id=="draservicebroker")' _toolchain.json; then
+if jq -e '.services[] | select(.service_id=="draservicebroker")' _toolchain.json > /dev/null 2>&1; then
   if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
     DEPLOYMENT_ENVIRONMENT="${PIPELINE_KUBERNETES_CLUSTER_NAME}:${CLUSTER_NAMESPACE}"
   else 

--- a/scripts/check_predeploy_helm.sh
+++ b/scripts/check_predeploy_helm.sh
@@ -19,6 +19,10 @@ echo "CHART_NAME=${CHART_NAME}"
 echo "REGISTRY_URL=${REGISTRY_URL}"
 echo "REGISTRY_NAMESPACE=${REGISTRY_NAMESPACE}"
 echo "HELM_VERSION=${HELM_VERSION}"
+echo "KUBERNETES_SERVICE_ACCOUNT_NAME=${KUBERNETES_SERVICE_ACCOUNT_NAME}"
+
+echo "Use for custom Kubernetes cluster target:"
+echo "KUBERNETES_MASTER_ADDRESS=${KUBERNETES_MASTER_ADDRESS}"
 
 # View build properties
 if [ -f build.properties ]; then 
@@ -55,10 +59,14 @@ helm lint ${CHART_PATH}
 #Check cluster availability
 echo "=========================================================="
 echo "CHECKING CLUSTER readiness and namespace existence"
-IP_ADDR=$( bx cs workers ${PIPELINE_KUBERNETES_CLUSTER_NAME} | grep normal | awk '{ print $2 }' )
-if [ -z "${IP_ADDR}" ]; then
-  echo -e "${PIPELINE_KUBERNETES_CLUSTER_NAME} not created or workers not ready"
-  exit 1
+if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
+  IP_ADDR=$( bx cs workers ${PIPELINE_KUBERNETES_CLUSTER_NAME} | grep normal | awk '{ print $2 }' )
+  if [ -z "${IP_ADDR}" ]; then
+    echo -e "${PIPELINE_KUBERNETES_CLUSTER_NAME} not created or workers not ready"
+    exit 1
+  fi
+else
+  IP_ADDR=${KUBERNETES_MASTER_ADDRESS}
 fi
 echo "Configuring cluster namespace"
 if kubectl get namespace ${CLUSTER_NAMESPACE}; then
@@ -89,20 +97,21 @@ if [ -z "${CHART_PULL_SECRET}" ]; then
   echo "INFO: Chart is not expecting an explicit private registry imagePullSecret. Patching the cluster default serviceAccount to pass it implicitly instead."
   echo "      Learn how to inject pull secrets into the deployment chart at: https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod"
   echo "      or check out this chart example: https://github.com/open-toolchain/hello-helm/tree/master/chart/hello"
-  SERVICE_ACCOUNT=$(kubectl get serviceaccount default  -o json --namespace ${CLUSTER_NAMESPACE} )
+  if [ -z "${KUBERNETES_SERVICE_ACCOUNT_NAME}" ]; then KUBERNETES_SERVICE_ACCOUNT_NAME="default" ; fi
+  SERVICE_ACCOUNT=$(kubectl get serviceaccount ${KUBERNETES_SERVICE_ACCOUNT_NAME}  -o json --namespace ${CLUSTER_NAMESPACE} )
   if ! echo ${SERVICE_ACCOUNT} | jq -e '. | has("imagePullSecrets")' > /dev/null ; then
     kubectl patch --namespace ${CLUSTER_NAMESPACE} serviceaccount/default -p '{"imagePullSecrets":[{"name":"'"${IMAGE_PULL_SECRET_NAME}"'"}]}'
   else
     if echo ${SERVICE_ACCOUNT} | jq -e '.imagePullSecrets[] | select(.name=="'"${IMAGE_PULL_SECRET_NAME}"'")' > /dev/null ; then 
-      echo -e "Pull secret already found in default serviceAccount"
+      echo -e "Pull secret already found in ${KUBERNETES_SERVICE_ACCOUNT_NAME} serviceAccount"
     else
-      echo "Inserting toolchain pull secret into default serviceAccount"
-      kubectl patch --namespace ${CLUSTER_NAMESPACE} serviceaccount/default --type='json' -p='[{"op":"add","path":"/imagePullSecrets/-","value":{"name": "'"${IMAGE_PULL_SECRET_NAME}"'"}}]'
+      echo "Inserting toolchain pull secret into ${KUBERNETES_SERVICE_ACCOUNT_NAME} serviceAccount"
+      kubectl patch --namespace ${CLUSTER_NAMESPACE} serviceaccount/${KUBERNETES_SERVICE_ACCOUNT_NAME} --type='json' -p='[{"op":"add","path":"/imagePullSecrets/-","value":{"name": "'"${IMAGE_PULL_SECRET_NAME}"'"}}]'
     fi
   fi
-  echo "default serviceAccount:"
-  kubectl get serviceaccount default --namespace ${CLUSTER_NAMESPACE} -o yaml
-  echo -e "Namespace ${CLUSTER_NAMESPACE} authorizing with private image registry using patched default serviceAccount"
+  echo "${KUBERNETES_SERVICE_ACCOUNT_NAME} serviceAccount:"
+  kubectl get serviceaccount ${KUBERNETES_SERVICE_ACCOUNT_NAME} --namespace ${CLUSTER_NAMESPACE} -o yaml
+  echo -e "Namespace ${CLUSTER_NAMESPACE} authorizing with private image registry using patched ${KUBERNETES_SERVICE_ACCOUNT_NAME} serviceAccount"  
 else
   echo -e "Namespace ${CLUSTER_NAMESPACE} authorized with private image registry using Helm chart imagePullSecret"
 fi
@@ -110,8 +119,8 @@ fi
 echo "=========================================================="
 echo "CHECKING HELM VERSION: matching Helm Tiller (server) if detected. "
 set +e
-LOCAL_VERSION=$( helm version --client | grep SemVer: | sed "s/^.*SemVer:\"v\([0-9.]*\).*/\1/" )
-TILLER_VERSION=$( helm version --server | grep SemVer: | sed "s/^.*SemVer:\"v\([0-9.]*\).*/\1/" )
+LOCAL_VERSION=$( helm version --client ${HELM_TLS_OPTION} | grep SemVer: | sed "s/^.*SemVer:\"v\([0-9.]*\).*/\1/" )
+TILLER_VERSION=$( helm version --server ${HELM_TLS_OPTION} | grep SemVer: | sed "s/^.*SemVer:\"v\([0-9.]*\).*/\1/" )
 set -e
 if [ -z "${TILLER_VERSION}" ]; then
   if [ -z "${HELM_VERSION}" ]; then
@@ -136,13 +145,13 @@ if [ -z "${TILLER_VERSION}" ]; then
     echo -e "Installing Helm Tiller ${CLIENT_VERSION} with cluster admin privileges (RBAC)"
     kubectl -n kube-system create serviceaccount tiller
     kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-    helm init --service-account tiller
+    helm init --service-account tiller ${HELM_TILLER_TLS_OPTION}
     # helm init --upgrade --force-upgrade
     kubectl --namespace=kube-system rollout status deploy/tiller-deploy
     # kubectl rollout status -w deployment/tiller-deploy --namespace=kube-system
 fi
-helm version
+helm version ${HELM_TLS_OPTION}
 
 echo "=========================================================="
 echo -e "CHECKING HELM releases in this namespace: ${CLUSTER_NAMESPACE}"
-helm list --namespace ${CLUSTER_NAMESPACE}
+helm list ${HELM_TLS_OPTION} --namespace ${CLUSTER_NAMESPACE}

--- a/scripts/check_predeploy_kubectl.sh
+++ b/scripts/check_predeploy_kubectl.sh
@@ -103,6 +103,6 @@ else
     kubectl patch --namespace ${CLUSTER_NAMESPACE} serviceaccount/${KUBERNETES_SERVICE_ACCOUNT_NAME} --type='json' -p='[{"op":"add","path":"/imagePullSecrets/-","value":{"name": "'"${IMAGE_PULL_SECRET_NAME}"'"}}]'
   fi
 fi
-echo "default serviceAccount:"
+echo "${KUBERNETES_SERVICE_ACCOUNT_NAME} serviceAccount:"
 kubectl get serviceaccount ${KUBERNETES_SERVICE_ACCOUNT_NAME} --namespace ${CLUSTER_NAMESPACE} -o yaml
-echo -e "Namespace ${CLUSTER_NAMESPACE} authorizing with private image registry using patched default serviceAccount"
+echo -e "Namespace ${CLUSTER_NAMESPACE} authorizing with private image registry using patched ${KUBERNETES_SERVICE_ACCOUNT_NAME} serviceAccount"

--- a/scripts/deploy_helm.sh
+++ b/scripts/deploy_helm.sh
@@ -142,7 +142,7 @@ if [[ ! -z "$NOT_READY" ]]; then
   kubectl describe pods --namespace ${CLUSTER_NAMESPACE}
   echo ""
   # Record failing deploy information
-  if jq -e '.services[] | select(.service_id=="draservicebroker")' _toolchain.json; then
+  if jq -e '.services[] | select(.service_id=="draservicebroker")' _toolchain.json > /dev/null 2>&1; then
     ibmcloud doi publishdeployrecord --env "${PIPELINE_KUBERNETES_CLUSTER_NAME}:${CLUSTER_NAMESPACE}" --logicalappname="${APPLICATION_NAME:-$IMAGE_NAME}" --buildnumber="$GIT_BRANCH:$SOURCE_BUILD_NUMBER" --status=fail
   fi
   #echo "Application Logs"
@@ -195,7 +195,7 @@ echo ""
 echo "=========================================================="
 echo "DEPLOYMENT SUCCEEDED"
 # Record passing deploy information
-if jq -e '.services[] | select(.service_id=="draservicebroker")' _toolchain.json; then
+if jq -e '.services[] | select(.service_id=="draservicebroker")' _toolchain.json > /dev/null 2>&1; then
   ibmcloud doi publishdeployrecord --env "${PIPELINE_KUBERNETES_CLUSTER_NAME}:${CLUSTER_NAMESPACE}" --logicalappname="${APPLICATION_NAME:-$IMAGE_NAME}" --buildnumber="$GIT_BRANCH:$SOURCE_BUILD_NUMBER" --status=pass
 fi
 if [ ! -z "${APP_SERVICE}" ]; then

--- a/scripts/deploy_helm.sh
+++ b/scripts/deploy_helm.sh
@@ -54,11 +54,13 @@ else
 fi
 
 echo "=========================================================="
-echo "DEFINE RELEASE by prefixing image (app) name with namespace if not 'default' as Helm needs unique release names across namespaces"
-if [[ "${CLUSTER_NAMESPACE}" != "default" ]]; then
-  RELEASE_NAME="${CLUSTER_NAMESPACE}-${IMAGE_NAME}"
-else
-  RELEASE_NAME=${IMAGE_NAME}
+if [ -z "$RELEASE_NAME" ]; then
+  echo "DEFINE RELEASE by prefixing image (app) name with namespace if not 'default' as Helm needs unique release names across namespaces"
+  if [[ "${CLUSTER_NAMESPACE}" != "default" ]]; then
+    RELEASE_NAME="${CLUSTER_NAMESPACE}-${IMAGE_NAME}"
+  else
+    RELEASE_NAME=${IMAGE_NAME}
+  fi
 fi
 echo -e "Release name: ${RELEASE_NAME}"
 


### PR DESCRIPTION
Update commons script to ease usage/consumption for helm based deployment:
- provide a way to use --tls option for helm invocation
- provide a way to use private worker for helm deployment (ie rely on a KUBERNETES_MASTER_ADDRESS env var)
- provide a way to specifiy RELEASE_NAME rather than force the computation of it
cf https://github.ibm.com/org-ids/roadmap/issues/10881