### PR TITLE
Change to curl -i option to support GET health endpoints

### DIFF
--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -63,7 +63,7 @@ echo ".$READINESS_PROBE_PATH."
 # READINESS_PROBE_PORT=$(echo $CONTAINERS_JSON | jq -r ".readinessProbe.httpGet.port" | head -n 1)
 if [ ${READINESS_PROBE_PATH} != null ]; then
   READINESS_PROBE_URL=${APP_URL}${READINESS_PROBE_PATH}
-  if [ "$(curl -Is ${READINESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+  if [ "$(curl -is ${READINESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
     echo "Successfully reached readiness probe endpoint: ${READINESS_PROBE_URL}"
     echo "====================================================================="
   else


### PR DESCRIPTION
The `-I` option currently used only supports HEAD requests. We are not sure of the impact of this change to other apps that use this template, but want to check if it is possible. This change is in light of a known issue in Swift Kitura (https://github.com/IBM-Swift/Kitura/issues/1414).