### PR TITLE
Use cluster id to get IP_ADDR instead of cluster name

### DIFF
--- a/scripts/check_and_deploy_helm.sh
+++ b/scripts/check_and_deploy_helm.sh
@@ -81,7 +81,7 @@ echo "=========================================================="
 echo "CHECKING CLUSTER readiness and namespace existence"
 if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
   CLUSTER_ID=$( kubectl config current-context | cut -d/ -f2 ) # use cluster id instead of cluster name to handle case where there are multiple clusters with same name
-  if [ -z "$CLUSTER_ID"]; then
+  if [ -z "$CLUSTER_ID" ]; then
     echo -e "kubectl config current-context returned:"
     kubectl config current-context
     echo - e "No cluster id found"

--- a/scripts/check_and_deploy_helm.sh
+++ b/scripts/check_and_deploy_helm.sh
@@ -81,6 +81,12 @@ echo "=========================================================="
 echo "CHECKING CLUSTER readiness and namespace existence"
 if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
   CLUSTER_ID=$( kubectl config current-context | cut -d/ -f2 ) # use cluster id instead of cluster name to handle case where there are multiple clusters with same name
+  if [ -z "$CLUSTER_ID"]; then
+    echo -e "kubectl config current-context returned:"
+    kubectl config current-context
+    echo - e "No cluster id found"
+    exit 1
+  fi
   IP_ADDR=$( ibmcloud ks workers --cluster ${CLUSTER_ID} | grep normal | head -n 1 | awk '{ print $2 }' )
   if [ -z "${IP_ADDR}" ]; then
     echo -e "${PIPELINE_KUBERNETES_CLUSTER_NAME} not created or workers not ready"

--- a/scripts/check_and_deploy_helm.sh
+++ b/scripts/check_and_deploy_helm.sh
@@ -80,12 +80,8 @@ helm lint ${CHART_PATH}
 echo "=========================================================="
 echo "CHECKING CLUSTER readiness and namespace existence"
 if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
-  IP_ADDR=$( ibmcloud ks workers --cluster ${PIPELINE_KUBERNETES_CLUSTER_NAME} | grep normal | head -n 1 | awk '{ print $2 }' )
-  if [ -z "${IP_ADDR}" ]; then
-    # If several clusters have same name, the above now fails, so switch to using the cluster id
-    CLUSTER_ID=$( ibmcloud ks cluster ls | grep ${PIPELINE_KUBERNETES_CLUSTER_NAME} | head -n 1 | awk '{ print $2 }' )
-    IP_ADDR=$( ibmcloud ks workers --cluster ${CLUSTER_ID} | grep normal | head -n 1 | awk '{ print $2 }' )
-  fi
+  CLUSTER_ID=$( kubectl config current-context | cut -d/ -f2 ) # use cluster id instead of cluster name to handle case where there are multiple clusters with same name
+  IP_ADDR=$( ibmcloud ks workers --cluster ${CLUSTER_ID} | grep normal | head -n 1 | awk '{ print $2 }' )
   if [ -z "${IP_ADDR}" ]; then
     echo -e "${PIPELINE_KUBERNETES_CLUSTER_NAME} not created or workers not ready"
     exit 1

--- a/scripts/check_and_deploy_helm.sh
+++ b/scripts/check_and_deploy_helm.sh
@@ -82,6 +82,11 @@ echo "CHECKING CLUSTER readiness and namespace existence"
 if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
   IP_ADDR=$( ibmcloud ks workers --cluster ${PIPELINE_KUBERNETES_CLUSTER_NAME} | grep normal | head -n 1 | awk '{ print $2 }' )
   if [ -z "${IP_ADDR}" ]; then
+    # If several clusters have same name, the above now fails, so switch to using the cluster id
+    CLUSTER_ID=$( ibmcloud ks cluster ls | grep ${PIPELINE_KUBERNETES_CLUSTER_NAME} | head -n 1 | awk '{ print $2 }' )
+    IP_ADDR=$( ibmcloud ks workers --cluster ${CLUSTER_ID} | grep normal | head -n 1 | awk '{ print $2 }' )
+  fi
+  if [ -z "${IP_ADDR}" ]; then
     echo -e "${PIPELINE_KUBERNETES_CLUSTER_NAME} not created or workers not ready"
     exit 1
   fi

--- a/scripts/check_and_deploy_helm.sh
+++ b/scripts/check_and_deploy_helm.sh
@@ -81,7 +81,6 @@ echo "=========================================================="
 echo "CHECKING CLUSTER readiness and namespace existence"
 if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
   CLUSTER_ID=$( kubectl config current-context | cut -d/ -f2 ) # use cluster id instead of cluster name to handle case where there are multiple clusters with same name
-  echo "CLUSTER_ID=$CLUSTER_ID"
   if [ -z "$CLUSTER_ID" ]; then
     echo -e "kubectl config current-context returned:"
     kubectl config current-context

--- a/scripts/check_and_deploy_helm.sh
+++ b/scripts/check_and_deploy_helm.sh
@@ -81,6 +81,7 @@ echo "=========================================================="
 echo "CHECKING CLUSTER readiness and namespace existence"
 if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
   CLUSTER_ID=$( kubectl config current-context | cut -d/ -f2 ) # use cluster id instead of cluster name to handle case where there are multiple clusters with same name
+  echo "CLUSTER_ID=$CLUSTER_ID"
   if [ -z "$CLUSTER_ID" ]; then
     echo -e "kubectl config current-context returned:"
     kubectl config current-context


### PR DESCRIPTION
As shown in https://github.ibm.com/org-ids/roadmap/issues/12941, if the same cluster name is used in multiple regions, retrieving the cluster ip address fails.
This pull request fixes the issue.