### PR TITLE
Fix getting exposed ports on check_and_deploy_kubectl.sh

### DIFF
--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -148,7 +148,7 @@ spec:
 EOT
 )
   # Find the port
-  PORT=$(ibmcloud cr image-inspect "${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}" --format '{{ range $key,$value := .ContainerConfig.ExposedPorts }} {{ $key }} {{ "" }} {{end}}' | sed -E 's/^[^0-9]*([0-9]+).*$/\1/') || true
+  PORT=$(ibmcloud cr image-inspect "${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}" --format '{{ range $key,$value := .Config.ExposedPorts }} {{ $key }} {{ "" }} {{end}}' | sed -E 's/^[^0-9]*([0-9]+).*$/\1/') || true
   if [ "$PORT" -eq "$PORT" ] 2>/dev/null; then
     echo "ExposedPort $PORT found while inspecting image ${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}"
   else 


### PR DESCRIPTION
This commit was using ContainerConfig which is not being set anymore
for buildkit/buildctl.

https://github.com/moby/buildkit/issues/1696#issuecomment-697705369

The commit changes it to use Config instead of ContainerConfig.

Signed-off-by: Anthony Amanse <ghieamanse@gmail.com>