### PR TITLE
Manage APP_URL with an ingress context to use runtime information

### DIFF
--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -278,6 +278,7 @@ echo ""
 echo "=========================================================="
 echo "DEPLOYMENT SUCCEEDED"
 if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ]; then
+  env | sort
   if [ -z "${APP_SERVICE}" ]; then
     APP_SERVICE=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} -o json | jq -r ' .items[] | select (.spec.selector.app=="'"${APP_NAME}"'" and .spec.type!="NodePort") | .metadata.name ')
   fi

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -282,7 +282,7 @@ fi
 echo ""
 echo "=========================================================="
 echo "DEPLOYMENT SUCCEEDED"
-if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ]; then
+if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ] && [ "${USE_ISTIO_GATEWAY}" != true ]; then
   APP_INGRESS=$(kubectl get ingress --namespace "$CLUSTER_NAMESPACE" -o json | jq -r --arg service_name "${APP_SERVICE}" ' .items[] | select (.spec.rules[].http.paths[].backend.serviceName==$service_name) | .metadata.name')
   INGRESS_JSON=$(kubectl get ingress --namespace "$CLUSTER_NAMESPACE" "${APP_INGRESS}" -o json)
   # Expose app using ingress host and path for the service

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -266,10 +266,13 @@ kubectl describe pods --selector app=${APP_NAME} --namespace ${CLUSTER_NAMESPACE
 APP_SERVICE=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} -o json | jq -r ' .items[] | select (.spec.selector.release=="'"${RELEASE_NAME}"'") | .metadata.name ')
 if [ -z "${APP_SERVICE}" ]; then
   # lookup service for current app with NodePort type
-  # unless there is an ingress subdomin in the cluster - in that the service that is not NodePort would be exposed
+  # unless there is an ingress subdomain in the cluster - in that the service that is not NodePort would be exposed
+  # First if ingress then look for a non NodePort service
   if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ]; then    
     APP_SERVICE=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} -o json | jq -r ' .items[] | select (.spec.selector.app=="'"${APP_NAME}"'" and .spec.type!="NodePort") | .metadata.name ')
-  else
+  fi
+  # If nothing found then fallback to a NodePort service
+  if [ -z "${APP_SERVICE}" ]; then
     APP_SERVICE=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} -o json | jq -r ' .items[] | select (.spec.selector.app=="'"${APP_NAME}"'" and .spec.type=="NodePort") | .metadata.name ')
   fi  
 fi

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -279,7 +279,9 @@ echo "=========================================================="
 echo "DEPLOYMENT SUCCEEDED"
 if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ]; then
   env | sort
+  echo $APP_SERVICE
   if [ -z "${APP_SERVICE}" ]; then
+    kubectl get services --namespace ${CLUSTER_NAMESPACE} -o json
     APP_SERVICE=$(kubectl get services --namespace ${CLUSTER_NAMESPACE} -o json | jq -r ' .items[] | select (.spec.selector.app=="'"${APP_NAME}"'" and .spec.type!="NodePort") | .metadata.name ')
   fi
   APP_INGRESS=$(kubectl get ingress --namespace $CLUSTER_NAMESPACE -o json | jq -r --arg service_name ${APP_SERVICE} ' .items[] | select (.spec.rules[].http.paths[].backend.serviceName==$service_name) | .metadata.name')

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -286,6 +286,8 @@ if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ]; then
   # Expose app using ingress host and path for the service
   APP_HOST=$(echo $INGRESS_JSON | jq -r --arg service_name "$APP_SERVICE" '.spec.rules[] | select(.http.paths[].backend.serviceName==$service_name) | .host')
   APP_PATH=$(echo $INGRESS_JSON | jq -r --arg service_name "$APP_SERVICE" '.spec.rules[].http.paths[] | select(.backend.serviceName==$service_name) | .path')
+  # Remove the last / from APP_PATH if any
+  APP_PATH=${APP_PATH%/}
   export APP_URL=https://${APP_HOST}${APP_PATH} # using 'export', the env var gets passed to next job in stage
   echo -e "VIEW THE APPLICATION AT: ${APP_URL}"
 else


### PR DESCRIPTION
Based on https://github.ibm.com/org-ids/roadmap/issues/14671 
the ingress definition may not be inlined in the deployment.yml especially when the ingress manage multiple endpoints from different services
This PR is to use ingress "runtime" information to retrieve the appropriate application url endpoint