### PR TITLE
Change to curl -i option to use HTTP GET for liveness probe endpoint

### DIFF
--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -47,7 +47,7 @@ echo ".$LIVENESS_PROBE_PATH."
 # LIVENESS_PROBE_PORT=$(echo $CONTAINERS_JSON | jq -r ".livenessProbe.httpGet.port" | head -n 1)
 if [ ${LIVENESS_PROBE_PATH} != null ]; then
   LIVENESS_PROBE_URL=${APP_URL}${LIVENESS_PROBE_PATH}
-  if [ "$(curl -Is ${LIVENESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+  if [ "$(curl -is ${LIVENESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
     echo "Successfully reached liveness probe endpoint: ${LIVENESS_PROBE_URL}"
     echo "====================================================================="
   else


### PR DESCRIPTION
This is consistent and adhere to Kubernetes Standard that is using HTTP GET (and not HTTP HEAD request) for liveness/readiness probes - https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
There is a companion PR for the readiness probe - https://github.com/open-toolchain/commons/pull/49