### PR TITLE
Update ingress hostname and secret query to accept both v1 or v2 structure (classic or vpcgen2)

### DIFF
--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -64,8 +64,9 @@ if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
     echo -e "${PIPELINE_KUBERNETES_CLUSTER_NAME} not created or workers not ready"
     exit 1
   fi
-  CLUSTER_INGRESS_SUBDOMAIN=$( ibmcloud ks cluster get --cluster ${CLUSTER_ID} --json | jq -r '.ingressHostname' | cut -d, -f1 )
-  CLUSTER_INGRESS_SECRET=$( ibmcloud ks cluster get --cluster ${CLUSTER_ID} --json | jq -r '.ingressSecretName' | cut -d, -f1 )
+  # Use alternate operator .ingress.XXX for vpc/gen2 / apiv2 cluster
+  CLUSTER_INGRESS_SUBDOMAIN=$( ibmcloud ks cluster get --cluster ${CLUSTER_ID} --json | jq -r '.ingressHostname // .ingress.hostname' | cut -d, -f1 )
+  CLUSTER_INGRESS_SECRET=$( ibmcloud ks cluster get --cluster ${CLUSTER_ID} --json | jq -r '.ingressSecretName // .ingress.secretName' | cut -d, -f1 )
 fi
 echo "Configuring cluster namespace"
 if kubectl get namespace ${CLUSTER_NAMESPACE}; then


### PR DESCRIPTION
Due to change in json structure for iks cluster
>> v2 was introduced with VPC support; it is more generic than v1 and better differentiates resource states and messages