### PR TITLE
update buildkit version

### DIFF
--- a/scripts/build_image_buildkit.sh
+++ b/scripts/build_image_buildkit.sh
@@ -57,7 +57,7 @@ if which buildctl > /dev/null 2>&1; then
   buildctl --version
 else 
   echo "Installing Buildkit builctl"
-  curl -sL https://github.com/moby/buildkit/releases/download/v0.7.2/buildkit-v0.7.2.linux-amd64.tar.gz | tar -C /tmp -xz bin/buildctl && mv /tmp/bin/buildctl /usr/bin/buildctl && rmdir --ignore-fail-on-non-empty /tmp/bin
+  curl -sL https://github.com/moby/buildkit/releases/download/v0.8.1/buildkit-v0.8.1.linux-amd64.tar.gz | tar -C /tmp -xz bin/buildctl && mv /tmp/bin/buildctl /usr/bin/buildctl && rmdir --ignore-fail-on-non-empty /tmp/bin
   buildctl --version
 fi
 


### PR DESCRIPTION
v0.7.2 causes this issue when building Watson starter kits:
```
error: failed to solve: rpc error: code = Unknown desc = invalid incomplete links
```

This issue is fixed in v.0.8.0: https://github.com/moby/buildkit/issues/1509