### PR TITLE
Allow to keep ingress custom domain in ingress definition of deployment.yaml

### DIFF
--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -291,6 +291,7 @@ fi
 echo ""
 echo "=========================================================="
 echo "DEPLOYMENT SUCCEEDED"
+APP_URL=""
 echo "CLUSTER_INGRESS_SUBDOMAIN=$CLUSTER_INGRESS_SUBDOMAIN"
 echo "USE_ISTIO_GATEWAY=$USE_ISTIO_GATEWAY"
 if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ] && [ "${USE_ISTIO_GATEWAY}" != true ]; then

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -20,6 +20,7 @@ echo "REGISTRY_URL=${REGISTRY_URL}"
 echo "REGISTRY_NAMESPACE=${REGISTRY_NAMESPACE}"
 echo "DEPLOYMENT_FILE=${DEPLOYMENT_FILE}"
 echo "USE_ISTIO_GATEWAY=${USE_ISTIO_GATEWAY}"
+echo "KEEP_INGRESS_CUSTOM_DOMAIN=${KEEP_INGRESS_CUSTOM_DOMAIN}"
 echo "KUBERNETES_SERVICE_ACCOUNT_NAME=${KUBERNETES_SERVICE_ACCOUNT_NAME}"
 
 echo "Use for custom Kubernetes cluster target:"
@@ -181,7 +182,7 @@ yq write $DEPLOYMENT_FILE --doc $DEPLOYMENT_DOC_INDEX "spec.template.spec.contai
 DEPLOYMENT_FILE=${NEW_DEPLOYMENT_FILE} # use modified file
 cat ${DEPLOYMENT_FILE}
 
-if [ ! -z "${CLUSTER_INGRESS_SUBDOMAIN}" ]; then
+if [ ! -z "${CLUSTER_INGRESS_SUBDOMAIN}" ] && [ "${KEEP_INGRESS_CUSTOM_DOMAIN}" != true ]; then
   echo "=========================================================="
   echo "UPDATING manifest with ingress information"
   INGRESS_DOC_INDEX=$(yq read --doc "*" --tojson $DEPLOYMENT_FILE | jq -r 'to_entries | .[] | select(.value.kind | ascii_downcase=="ingress") | .key')

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -317,11 +317,12 @@ if [ -z "$APP_URL" ] && [ "$APP_SERVICE" ]; then
   # Fallback according to the service type
   if [ "$APP_SERVICE_TYPE" = "NodePort" ]; then
     # Only NodePort will be available
-    echo ""
+    echo "Only NodePort will be available"
     if [ "${USE_ISTIO_GATEWAY}" = true ]; then
       PORT=$( kubectl get svc istio-ingressgateway -n istio-system -o json | jq -r '.spec.ports[] | select (.name=="http2") | .nodePort ' )
       echo -e "*** istio gateway enabled ***"
     else
+      echo "Looking for port using: kubectl get service ${APP_SERVICE} --namespace ${CLUSTER_NAMESPACE}"
       PORT=$( kubectl get service ${APP_SERVICE} --namespace ${CLUSTER_NAMESPACE} -o json | jq -r '.spec.ports[0].nodePort' )
     fi
     if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -68,6 +68,9 @@ if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
   # Use alternate operator .ingress.XXX for vpc/gen2 / apiv2 cluster
   CLUSTER_INGRESS_SUBDOMAIN=$( ibmcloud ks cluster get --cluster ${CLUSTER_ID} --json | jq -r '.ingressHostname // .ingress.hostname' | cut -d, -f1 )
   CLUSTER_INGRESS_SECRET=$( ibmcloud ks cluster get --cluster ${CLUSTER_ID} --json | jq -r '.ingressSecretName // .ingress.secretName' | cut -d, -f1 )
+else
+  CLUSTER_INGRESS_SUBDOMAIN=""
+  CLUSTER_INGRESS_SECRET=""
 fi
 echo "Configuring cluster namespace"
 if kubectl get namespace ${CLUSTER_NAMESPACE}; then

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -363,7 +363,7 @@ EOF
       IP_ADDR=${KUBERNETES_MASTER_ADDRESS}
       PORT=$(kubectl get service ${APP_SERVICE} --namespace ${CLUSTER_NAMESPACE} -o json | jq -r '.spec.ports[0].port')
     fi
-    export APP_URL="http://${IP_ADDR}:${PORT}" # using 'export', the env var gets passed to next job in stage
+    export APP_URL=http://${IP_ADDR}:${PORT} # using 'export', the env var gets passed to next job in stage
     echo -e "VIEW THE APPLICATION AT: ${APP_URL}"
   fi
 fi

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -233,7 +233,7 @@ if kubectl rollout status deploy/${DEPLOYMENT_NAME} --watch=true --timeout=${ROL
 else
   STATUS="fail"
 fi
-#set +x
+set +x
 
 # Dump events that occured during the rollout
 echo "SHOWING last events"
@@ -286,14 +286,14 @@ if [ ! -z "${APP_SERVICE}" ]; then
   echo -e "SERVICE: ${APP_SERVICE}"
   echo "DEPLOYED SERVICES:"
   kubectl describe services ${APP_SERVICE} --namespace ${CLUSTER_NAMESPACE}
+else
+  APP_SERVICE_TYPE=""
 fi
 
 echo ""
 echo "=========================================================="
 echo "DEPLOYMENT SUCCEEDED"
 APP_URL=""
-echo "CLUSTER_INGRESS_SUBDOMAIN=$CLUSTER_INGRESS_SUBDOMAIN"
-echo "USE_ISTIO_GATEWAY=$USE_ISTIO_GATEWAY"
 if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ] && [ "${USE_ISTIO_GATEWAY}" != true ]; then
   APP_INGRESS=$(kubectl get ingress --namespace "$CLUSTER_NAMESPACE" -o json | jq -r --arg service_name "${APP_SERVICE}" ' .items[] | first(select(.spec.rules[].http.paths[].backend.serviceName==$service_name)) | .metadata.name')
   if [ "$APP_INGRESS" ]; then
@@ -310,13 +310,9 @@ if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ] && [ "${USE_ISTIO_GATEWAY}" != true ]; the
     echo -e "VIEW THE APPLICATION AT: ${APP_URL}"
   fi
 fi
-echo "APP_URL=$APP_URL"
-echo "APP_SERVICE=$APP_SERVICE"
-echo "APP_SERVICE_TYPE=$APP_SERVICE_TYPE"
 if [ -z "$APP_URL" ] && [ "$APP_SERVICE" ]; then
   # No ingress resource linked the given service
   # Fallback according to the service type
-  echo "No Ingress resource linked"
   if [ "$APP_SERVICE_TYPE" = "NodePort" ]; then
     # Only NodePort will be available
     echo "Only NodePort will be available"
@@ -330,7 +326,6 @@ if [ -z "$APP_URL" ] && [ "$APP_SERVICE" ]; then
     if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
       echo "Using first worker node ip address as NodeIP: ${IP_ADDR}"
     else 
-      echo "Check for route concept"
       # check if a route resource exists in the this kubernetes cluster
       if kubectl explain route > /dev/null 2>&1; then
         # Assuming the kubernetes target cluster is an openshift cluster

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -307,6 +307,9 @@ if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ] && [ "${USE_ISTIO_GATEWAY}" != true ]; the
     echo -e "VIEW THE APPLICATION AT: ${APP_URL}"
   fi
 fi
+echo "APP_URL=$APP_URL"
+echo "APP_SERVICE=$APP_SERVICE"
+echo "APP_SERVICE_TYPE=$APP_SERVICE_TYPE"
 if [ -z "$APP_URL" ] && [ "$APP_SERVICE" ]; then
   # No ingress resource linked the given service
   # Fallback according to the service type

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -315,12 +315,11 @@ if [ -z "$APP_URL" ] && [ "$APP_SERVICE" ]; then
   # Fallback according to the service type
   if [ "$APP_SERVICE_TYPE" = "NodePort" ]; then
     # Only NodePort will be available
-    echo "Only NodePort will be available"
+    echo ""
     if [ "${USE_ISTIO_GATEWAY}" = true ]; then
       PORT=$( kubectl get svc istio-ingressgateway -n istio-system -o json | jq -r '.spec.ports[] | select (.name=="http2") | .nodePort ' )
       echo -e "*** istio gateway enabled ***"
     else
-      echo "Looking for port using: kubectl get service ${APP_SERVICE} --namespace ${CLUSTER_NAMESPACE}"
       PORT=$( kubectl get service ${APP_SERVICE} --namespace ${CLUSTER_NAMESPACE} -o json | jq -r '.spec.ports[0].nodePort' )
     fi
     if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -291,6 +291,8 @@ fi
 echo ""
 echo "=========================================================="
 echo "DEPLOYMENT SUCCEEDED"
+echo "CLUSTER_INGRESS_SUBDOMAIN=$CLUSTER_INGRESS_SUBDOMAIN"
+echo "USE_ISTIO_GATEWAY=$USE_ISTIO_GATEWAY"
 if [ "${CLUSTER_INGRESS_SUBDOMAIN}" ] && [ "${USE_ISTIO_GATEWAY}" != true ]; then
   APP_INGRESS=$(kubectl get ingress --namespace "$CLUSTER_NAMESPACE" -o json | jq -r --arg service_name "${APP_SERVICE}" ' .items[] | first(select(.spec.rules[].http.paths[].backend.serviceName==$service_name)) | .metadata.name')
   if [ "$APP_INGRESS" ]; then

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -315,6 +315,7 @@ echo "APP_SERVICE_TYPE=$APP_SERVICE_TYPE"
 if [ -z "$APP_URL" ] && [ "$APP_SERVICE" ]; then
   # No ingress resource linked the given service
   # Fallback according to the service type
+  echo "No Ingress resource linked"
   if [ "$APP_SERVICE_TYPE" = "NodePort" ]; then
     # Only NodePort will be available
     echo "Only NodePort will be available"
@@ -328,6 +329,7 @@ if [ -z "$APP_URL" ] && [ "$APP_SERVICE" ]; then
     if [ -z "${KUBERNETES_MASTER_ADDRESS}" ]; then
       echo "Using first worker node ip address as NodeIP: ${IP_ADDR}"
     else 
+      echo "Check for route concept"
       # check if a route resource exists in the this kubernetes cluster
       if kubectl explain route > /dev/null 2>&1; then
         # Assuming the kubernetes target cluster is an openshift cluster
@@ -366,7 +368,7 @@ EOF
       IP_ADDR=${KUBERNETES_MASTER_ADDRESS}
       PORT=$(kubectl get service ${APP_SERVICE} --namespace ${CLUSTER_NAMESPACE} -o json | jq -r '.spec.ports[0].port')
     fi
-    export APP_URL=http://${IP_ADDR}:${PORT} # using 'export', the env var gets passed to next job in stage
+    export APP_URL="http://${IP_ADDR}:${PORT}" # using 'export', the env var gets passed to next job in stage
     echo -e "VIEW THE APPLICATION AT: ${APP_URL}"
   fi
 fi

--- a/scripts/check_and_deploy_kubectl.sh
+++ b/scripts/check_and_deploy_kubectl.sh
@@ -230,7 +230,7 @@ if kubectl rollout status deploy/${DEPLOYMENT_NAME} --watch=true --timeout=${ROL
 else
   STATUS="fail"
 fi
-set +x
+#set +x
 
 # Dump events that occured during the rollout
 echo "SHOWING last events"


### PR DESCRIPTION
If the environment variable `KEEP_INGRESS_CUSTOM_DOMAIN` is equals to `true` then the update of the ingress definition in the deployment.yaml will not be performed using the IBM provided default custom domain name of the target cluster
Fix for https://github.ibm.com/org-ids/roadmap/issues/16159