### PR TITLE
Restrict to namespace when listing existing images

### DIFF
--- a/scripts/build_image_buildkit.sh
+++ b/scripts/build_image_buildkit.sh
@@ -37,8 +37,8 @@ fi
 # To review or change build options use:
 # ibmcloud cr build --help
 
-#echo -e "Existing images in registry"
-#ibmcloud cr images
+echo -e "Existing images in ${REGISTRY_NAMESPACE}"
+ibmcloud cr images --restrict ${REGISTRY_NAMESPACE}
 
 # Minting image tag using format: BUILD_NUMBER-BRANCH-COMMIT_ID-TIMESTAMP
 # e.g. 3-master-50da6912-20181123114435

--- a/scripts/build_image_buildkit.sh
+++ b/scripts/build_image_buildkit.sh
@@ -37,8 +37,8 @@ fi
 # To review or change build options use:
 # ibmcloud cr build --help
 
-echo -e "Existing images in registry"
-ibmcloud cr images
+#echo -e "Existing images in registry"
+#ibmcloud cr images
 
 # Minting image tag using format: BUILD_NUMBER-BRANCH-COMMIT_ID-TIMESTAMP
 # e.g. 3-master-50da6912-20181123114435

--- a/scripts/build_image_buildkit.sh
+++ b/scripts/build_image_buildkit.sh
@@ -37,9 +37,6 @@ fi
 # To review or change build options use:
 # ibmcloud cr build --help
 
-echo -e "Existing images in ${REGISTRY_NAMESPACE}"
-ibmcloud cr images --restrict ${REGISTRY_NAMESPACE}
-
 # Minting image tag using format: BUILD_NUMBER-BRANCH-COMMIT_ID-TIMESTAMP
 # e.g. 3-master-50da6912-20181123114435
 # (use build number as first segment to allow image tag as a patch release name according to semantic versioning)


### PR DESCRIPTION
Listing existing images can be a very expensive operation when you have thousands of existing images. It can last several minutes.