### PR TITLE
Follow redirect for health check

### DIFF
--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -52,7 +52,7 @@ echo "LIVENESS_PROBE_PATH .$LIVENESS_PROBE_PATH."
 if [ ${LIVENESS_PROBE_PATH} != null ]; then
   LIVENESS_PROBE_URL=${APP_URL}${LIVENESS_PROBE_PATH}
   # command with help from https://superuser.com/a/1176569
-  if [ "$(curl -isL ${LIVENESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 -o /dev/null -w '%{http_code}' -s)" == "200" ]; then
+  if [ "$(curl -isL ${LIVENESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 -o /dev/null -w '%{http_code}')" == "200" ]; then
     echo "Successfully reached liveness probe endpoint: ${LIVENESS_PROBE_URL}"
     echo "====================================================================="
   else
@@ -69,7 +69,7 @@ echo "READINESS_PROBE_PATH .$READINESS_PROBE_PATH."
 if [ ${READINESS_PROBE_PATH} != null ]; then
   READINESS_PROBE_URL=${APP_URL}${READINESS_PROBE_PATH}
   # command with help from https://superuser.com/a/1176569
-  if [ "$(curl -isL ${READINESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 -o /dev/null -w '%{http_code}' -s)" == "200" ]; then
+  if [ "$(curl -isL ${READINESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 -o /dev/null -w '%{http_code}')" == "200" ]; then
     echo "Successfully reached readiness probe endpoint: ${READINESS_PROBE_URL}"
     echo "====================================================================="
   else

--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -51,7 +51,8 @@ echo "LIVENESS_PROBE_PATH .$LIVENESS_PROBE_PATH."
 # LIVENESS_PROBE_PORT=$(echo $CONTAINERS_JSON | jq -r ".livenessProbe.httpGet.port" | head -n 1)
 if [ ${LIVENESS_PROBE_PATH} != null ]; then
   LIVENESS_PROBE_URL=${APP_URL}${LIVENESS_PROBE_PATH}
-  # command with help from https://superuser.com/a/1176569
+
+  # command to get HTTP code from curl with help from https://superuser.com/a/1176569
   if [ "$(curl -isL ${LIVENESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 -o /dev/null -w '%{http_code}')" == "200" ]; then
     echo "Successfully reached liveness probe endpoint: ${LIVENESS_PROBE_URL}"
     echo "====================================================================="
@@ -65,10 +66,11 @@ fi
 
 READINESS_PROBE_PATH=$(echo $CONTAINERS_JSON | jq -r ".readinessProbe.httpGet.path" | head -n 1)
 echo "READINESS_PROBE_PATH .$READINESS_PROBE_PATH."
+
 # READINESS_PROBE_PORT=$(echo $CONTAINERS_JSON | jq -r ".readinessProbe.httpGet.port" | head -n 1)
 if [ ${READINESS_PROBE_PATH} != null ]; then
   READINESS_PROBE_URL=${APP_URL}${READINESS_PROBE_PATH}
-  # command with help from https://superuser.com/a/1176569
+  # command to get HTTP code from curl with help from https://superuser.com/a/1176569
   if [ "$(curl -isL ${READINESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 -o /dev/null -w '%{http_code}')" == "200" ]; then
     echo "Successfully reached readiness probe endpoint: ${READINESS_PROBE_URL}"
     echo "====================================================================="

--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -51,7 +51,8 @@ echo "LIVENESS_PROBE_PATH .$LIVENESS_PROBE_PATH."
 # LIVENESS_PROBE_PORT=$(echo $CONTAINERS_JSON | jq -r ".livenessProbe.httpGet.port" | head -n 1)
 if [ ${LIVENESS_PROBE_PATH} != null ]; then
   LIVENESS_PROBE_URL=${APP_URL}${LIVENESS_PROBE_PATH}
-  if [ "$(curl -is ${LIVENESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+  # command with help from https://superuser.com/a/1176569
+  if [ "$(curl -isL ${LIVENESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 -o /dev/null -w '%{http_code}' -s)" == "200" ]; then
     echo "Successfully reached liveness probe endpoint: ${LIVENESS_PROBE_URL}"
     echo "====================================================================="
   else
@@ -67,7 +68,8 @@ echo "READINESS_PROBE_PATH .$READINESS_PROBE_PATH."
 # READINESS_PROBE_PORT=$(echo $CONTAINERS_JSON | jq -r ".readinessProbe.httpGet.port" | head -n 1)
 if [ ${READINESS_PROBE_PATH} != null ]; then
   READINESS_PROBE_URL=${APP_URL}${READINESS_PROBE_PATH}
-  if [ "$(curl -is ${READINESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 | head -n 1 | grep 200)" != "" ]; then
+  # command with help from https://superuser.com/a/1176569
+  if [ "$(curl -isL ${READINESS_PROBE_URL} --connect-timeout 3 --max-time 5 --retry 2 --retry-max-time 30 -o /dev/null -w '%{http_code}' -s)" == "200" ]; then
     echo "Successfully reached readiness probe endpoint: ${READINESS_PROBE_URL}"
     echo "====================================================================="
   else


### PR DESCRIPTION
`-L` is to follow redirect
`-o /dev/null -w '%{http_code}' -s` is to return the last http status code by itself (see SU link)