### PR TITLE
move helm lint after final helm version

### DIFF
--- a/scripts/check_and_deploy_helm3.sh
+++ b/scripts/check_and_deploy_helm3.sh
@@ -82,8 +82,6 @@ if [ -z "${CHART_PATH}" ]; then
 else
     echo -e "Helm chart found for Kubernetes deployment : ${CHART_PATH}"
 fi
-echo "Linting Helm Chart"
-helm lint ${CHART_PATH}
 
 #Check cluster availability
 echo "=========================================================="
@@ -175,6 +173,9 @@ elif [ "${CLIENT_VERSION}" != "${LOCAL_VERSION}" ]; then
 fi
 set -e
 helm version ${HELM_TLS_OPTION}
+
+echo "Linting Helm Chart"
+helm lint ${CHART_PATH}
 
 echo "=========================================================="
 echo -e "CHECKING HELM releases in this namespace: ${CLUSTER_NAMESPACE}"


### PR DESCRIPTION
ubuntu toolchain image has helm 2 as default installation. If a helm chart uses helm version 3, helm lint will break as helm client uses version 2 and chart.yaml apiVersion is v2.

We need to move helm lint after finally settling on the helm version to use